### PR TITLE
uses tone_id instead of tone_name for avg sentiment

### DIFF
--- a/server/lib/processUtils.js
+++ b/server/lib/processUtils.js
@@ -1,5 +1,4 @@
 
-
 const getMaxIndex = array =>
       array.findIndex(el => el.score === Math.max(...array.map(tone => tone.score)));
 
@@ -7,5 +6,6 @@ module.exports.clone = obj => JSON.parse(JSON.stringify(obj));
 
 module.exports.textSummary = (textAnalysis) => {
   const tones = textAnalysis.document_tone.tone_categories[0].tones;
-  return tones[getMaxIndex(tones)].tone_name;
+  return tones[getMaxIndex(tones)].tone_id;
 };
+


### PR DESCRIPTION
tone_id is all lowercase instead of tone_name which is capitalized. This change is to conform to the
interface spec requirements.