### PR TITLE
fixes divide by zero case when no sentiment is detected

### DIFF
--- a/server/lib/processUtils.js
+++ b/server/lib/processUtils.js
@@ -16,7 +16,7 @@ module.exports.textSummary = (textAnalysis) => {
 
 const normalizeSummary = (aggregate) => {
   Object.keys(aggregate.summary).forEach((emotion) => {
-    aggregate.summary[emotion] /= aggregate.total; // eslint-disable-line
+    aggregate.summary[emotion] /= aggregate.total ? aggregate.total : 1; // eslint-disable-line
   });
   delete aggregate.total; // eslint-disable-line
   return aggregate;


### PR DESCRIPTION
This fixes the case where no sentiment is being detected and the summary is being normalized, resulting in a division by zero.